### PR TITLE
Check res.headersSent before calling res.setHeader() in bail()

### DIFF
--- a/server.js
+++ b/server.js
@@ -135,7 +135,9 @@ function createServer() {
     var message = [err.message, err.stack].join('\n')
 
     res.statusCode = 500
-    res.setHeader('content-type', 'text/plain')
+    if (!res.headersSent) {
+      res.setHeader('content-type', 'text/plain')
+    }
     res.end(message)
     console.error(message)
   }


### PR DESCRIPTION
I noticed sometimes `bail()` would be called after headers had already been written on the response. In this case, instead of writing the error back on the response, it throws and kills the server process. 

This fix just doesn't set `text/plain` if headers have already been written, so the error is written to the request and the server can serve subsequent requests.
