### PR TITLE
Bump chokidar version to allow use on node v4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "dependencies": {
-    "chokidar": "^0.8.2",
+    "chokidar": "^1.1.0",
     "envify": "^2.0.0",
     "esprima": "^1.2.2",
     "events": "^1.0.1",


### PR DESCRIPTION
Chokidar 0.x uses a version of `fsevents` that won't compile on node ^4.0.0. This bumps the version of chokidar used so as to get things up and running.