### PR TITLE
Remove esprima-six dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "once": "^1.3.0",
     "replace-method": "0.0.0",
     "request": "^2.36.0",
-    "sleuth": "^0.1.0",
+    "sleuth": "^0.1.1",
     "sse-stream": "0.0.4",
     "static-eval": "^0.2.3",
     "through": "^2.3.4",
@@ -38,8 +38,10 @@
   "devDependencies": {
     "a-big-triangle": "0.0.0",
     "beefy": "^1.1.0",
+    "browserify": "^12.0.1",
     "gl-context": "^0.1.0",
-    "glslify": "^1.3.0"
+    "gl-shader": "^4.1.0",
+    "glslify": "^2.3.0"
   },
   "directories": {
     "test": "test"

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,13 @@ var canvas        = document.body.appendChild(document.createElement('canvas'))
 var triangle      = require('a-big-triangle')
 var createContext = require('gl-context')
 var glslify       = require('glslify')
+var glShader      = require('gl-shader')
 var gl            = createContext(canvas, render)
 
-var shader = glslify({
-    vert: './test.vert'
-  , frag: './test.frag'
-})(gl)
+var shader = glShader(gl
+  , glslify('./test.vert')
+  , glslify('./test.frag')
+)
 
 function render() {
   shader.bind()


### PR DESCRIPTION
This removes the esprima-six dependency (which means you can install the module via npm) but doesn't actually work and I'll need some help @hughsk to fix this up correctly. It appears that glslify-bundle has changed significantly since 1.6.0. If you give me some direction, I should be able to get something working. Thanks!
